### PR TITLE
[fix][broker] Fix REST API to produce messages to single-partitioned topics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/Topics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/Topics.java
@@ -104,7 +104,7 @@ public class Topics extends TopicsBase {
 
     @POST
     @Path("/non-persistent/{tenant}/{namespace}/{topic}")
-    @ApiOperation(value = "Produce message to a persistent topic.", response = String.class, responseContainer = "List")
+    @ApiOperation(value = "Produce message to a non-persistent topic.", response = String.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
             @ApiResponse(code = 404, message = "tenant/namespace/topic doesn't exit"),
@@ -132,7 +132,7 @@ public class Topics extends TopicsBase {
 
     @POST
     @Path("/non-persistent/{tenant}/{namespace}/{topic}/partitions/{partition}")
-    @ApiOperation(value = "Produce message to a partition of a persistent topic.",
+    @ApiOperation(value = "Produce message to a partition of a non-persistent topic.",
             response = String.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/Topics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/Topics.java
@@ -104,7 +104,8 @@ public class Topics extends TopicsBase {
 
     @POST
     @Path("/non-persistent/{tenant}/{namespace}/{topic}")
-    @ApiOperation(value = "Produce message to a non-persistent topic.", response = String.class, responseContainer = "List")
+    @ApiOperation(value = "Produce message to a non-persistent topic.", response = String.class,
+            responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
             @ApiResponse(code = 404, message = "tenant/namespace/topic doesn't exit"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
@@ -345,7 +345,7 @@ public class TopicsBase extends PersistentTopicsBase {
         List<String> redirectAddresses = Collections.synchronizedList(new ArrayList<>());
         CompletableFuture<Boolean> future = new CompletableFuture<>();
         List<CompletableFuture<Void>> lookupFutures = new ArrayList<>();
-        if (!topicName.isPartitioned() && metadata.partitions > 1) {
+        if (!topicName.isPartitioned() && metadata.partitions > 0) {
             // Partitioned topic with multiple partitions, need to do look up for each partition.
             for (int index = 0; index < metadata.partitions; index++) {
                 lookupFutures.add(lookUpBrokerForTopic(topicName.getPartition(index),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -96,6 +96,7 @@ import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class TopicsTest extends MockedPulsarServiceBaseTest {
@@ -166,10 +167,18 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
                 }).readValue(message);
     }
 
-    @Test
-    public void testProduceToPartitionedTopic() throws Exception {
+    @DataProvider(name = "partitionNumbers")
+    public Object[][] partitionNumbers() {
+        return new Object[][] {
+            {1},
+            {5},
+        };
+    }
+
+    @Test(dataProvider = "partitionNumbers")
+    public void testProduceToPartitionedTopic(int numPartitions) throws Exception {
         admin.topics().createPartitionedTopic("persistent://" + testTenant + "/" + testNamespace
-                + "/" + testTopicName + "-p", 5);
+                + "/" + testTopicName + "-p", numPartitions);
         AsyncResponse asyncResponse = mock(AsyncResponse.class);
         Schema<String> schema = StringSchema.utf8();
         ProducerMessages producerMessages = new ProducerMessages();
@@ -207,7 +216,7 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         }
         for (int index = 0; index < messagePerPartition.length; index++) {
             // We publish to each partition in round robin mode so each partition should get at most 2 message.
-            Assert.assertTrue(messagePerPartition[index] <= 2);
+            Assert.assertTrue(messagePerPartition[index] <= 10 / numPartitions);
         }
     }
 


### PR DESCRIPTION
Fixes #24442

### Motivation

The REST API fails to produce messages to single-partitioned topics  (partition count = 1) due to incorrect topic type detection.

### Modifications

- Fixed topic type detection condition in `TopicsBase` to properly handle  single-partitioned topics
- Changed from `if (!topicName.isPartitioned() && metadata.partitions > 1)` 
  to `if (!topicName.isPartitioned() && metadata.partitions > 0)`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Extended `TopicsTest.testProduceToPartitionedTopic` test cases with single-partition topic testing.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Joforde/pulsar/commit/408ac9d5fa193fe1f6a76ced59c4cd2686f3b546

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
